### PR TITLE
fix: Use upper-case hash algorithm names

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,7 @@ Change history for App-CPAN-SBOM
     - Added "cyclonedx-spec-version" option to allows specify CycloneDX
       specification version (default: 1.5)
     - Switched to upcoming CPAN PURL type
+    - Fixed incompatibility with SBOM::CycloneDX v1.08
 
 1.03 2025-08-11
     - Added "DTRACK_*" env variables for CI/CD

--- a/lib/App/CPAN/SBOM.pm
+++ b/lib/App/CPAN/SBOM.pm
@@ -538,11 +538,11 @@ sub make_dep_compoment {
     my $hashes = SBOM::CycloneDX::List->new;
 
     if (my $checksum = $dist_data->checksum_sha256) {
-        $hashes->add(SBOM::CycloneDX::Hash->new(alg => 'sha-256', content => $checksum));
+        $hashes->add(SBOM::CycloneDX::Hash->new(alg => 'SHA-256', content => $checksum));
     }
 
     if (my $checksum = $dist_data->checksum_md5) {
-        $hashes->add(SBOM::CycloneDX::Hash->new(alg => 'md5', content => $checksum));
+        $hashes->add(SBOM::CycloneDX::Hash->new(alg => 'MD5', content => $checksum));
     }
 
     my $component = SBOM::CycloneDX::Component->new(


### PR DESCRIPTION
This should fix giterlizzi/perl-App-CPAN-SBOM#9 caused by `SBOM::CycloneDX` v1.08